### PR TITLE
Disables UITableViewCell from Accidentally being selected.

### DIFF
--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -75,6 +75,9 @@
 	cell.rightTextField.placeholder = [self.placeholders objectAtIndex:indexPath.row];
 	cell.indexPath = indexPath;
 	cell.delegate = self;
+        //Disables UITableViewCell from accidentally becoming selected.
+        cell.selectionStyle = UITableViewCellEditingStyleNone;
+
 	
 	if(indexPath.row == 3) {
 	


### PR DESCRIPTION
In the previous version, if a user accidentally tapped the UITableViewCell  in an area not containing the a UITextField, the cell would become highlighted. This change prevents that from happening and confusing the user.
