### PR TITLE
Fixing a bug related to cell deallocation

### DIFF
--- a/Classes/ELCTextfieldCell.h
+++ b/Classes/ELCTextfieldCell.h
@@ -8,25 +8,20 @@
 
 #import <UIKit/UIKit.h>
 
+@class ELCTextfieldCell;
 
-@interface ELCTextfieldCell : UITableViewCell <UITextFieldDelegate> {
+@protocol ELCTextFieldDelegate <NSObject>
+@optional
+-(BOOL)textField:(ELCTextfieldCell *)inCell shouldReturnForIndexPath:(NSIndexPath*)inIndexPath withValue:(NSString *)inValue;
+-(void)textField:(ELCTextfieldCell *)inCell didReturnWithIndexPath:(NSIndexPath*)inIndexPath withValue:(NSString *)inValue;
+-(void)textField:(ELCTextfieldCell *)inCell updateTextLabelAtIndexPath:(NSIndexPath *)inIndexPath string:(NSString *)inValue;
+@end
 
-	id delegate;
-	UILabel *leftLabel;
-	UITextField *rightTextField;
-	NSIndexPath *indexPath;
-}
-
-@property (nonatomic, assign) id delegate;
+@interface ELCTextfieldCell : UITableViewCell <UITextFieldDelegate> 
+@property (nonatomic, assign) id<ELCTextFieldDelegate> delegate;
 @property (nonatomic, retain) UILabel *leftLabel;
 @property (nonatomic, retain) UITextField *rightTextField;
 @property (nonatomic, retain) NSIndexPath *indexPath;
 
 @end
 
-@protocol ELCTextFieldDelegate
-
--(void)textFieldDidReturnWithIndexPath:(NSIndexPath*)_indexPath;
--(void)updateTextLabelAtIndexPath:(NSIndexPath*)_indexPath string:(NSString*)_string;
-
-@end

--- a/Classes/ELCTextfieldCell.m
+++ b/Classes/ELCTextfieldCell.m
@@ -65,15 +65,29 @@
     [super setSelected:selected animated:animated];
 }
 
+- (BOOL)textFieldShouldEndEditing:(UITextField *)textField
+{
+    return YES;
+}
+
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
 	
-	if([delegate respondsToSelector:@selector(textFieldDidReturnWithIndexPath:)]) {
-		
-		[delegate performSelector:@selector(textFieldDidReturnWithIndexPath:) withObject:indexPath];
+    BOOL ret = YES;
+	if([delegate respondsToSelector:@selector(textField:shouldReturnForIndexPath:withValue:)])
+    {
+        ret = [delegate textField:self shouldReturnForIndexPath:indexPath withValue:self.rightTextField.text];
 	}
-	
-	return YES;
+    if(ret)
+        [textField resignFirstResponder];
+    return ret;
 }
+
+- (void)textFieldDidEndEditing:(UITextField *)textField
+{
+    if([delegate respondsToSelector:@selector(textField:didReturnWithIndexPath:withValue:)])
+        [delegate textField:self didReturnWithIndexPath:indexPath withValue:self.rightTextField.text];
+}
+
 
 - (BOOL) textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
 
@@ -97,15 +111,16 @@
 		}
 	}
 	
-	if([delegate respondsToSelector:@selector(updateTextLabelAtIndexPath:string:)]) {		
-		[delegate performSelector:@selector(updateTextLabelAtIndexPath:string:) withObject:indexPath withObject:textString];
+	if([delegate respondsToSelector:@selector(textField:updateTextLabelAtIndexPath:string:)]) 
+    {
+		[delegate textField:self updateTextLabelAtIndexPath:indexPath string:textString];
 	}
 	
 	return YES;
 }
 
 - (void)dealloc {
-    [rightTextField resignFirstResponder];	
+	[rightTextField resignFirstResponder];
 	[leftLabel release];
 	[rightTextField release];
 	[indexPath release];

--- a/Classes/ELCTextfieldCell.m
+++ b/Classes/ELCTextfieldCell.m
@@ -105,7 +105,7 @@
 }
 
 - (void)dealloc {
-	
+    [rightTextField resignFirstResponder];	
 	[leftLabel release];
 	[rightTextField release];
 	[indexPath release];


### PR DESCRIPTION
In some cases, if a cell is deallocated while the right text field has first responder, the keyboard will not dismiss.  This fixes that problem.
